### PR TITLE
Added new signature encoding scheme

### DIFF
--- a/actions/README.md
+++ b/actions/README.md
@@ -11,9 +11,9 @@ Collection of GitHub Actions used to co-sign transactions.
 - [Check Transaction](./check/)
 
   Action to check and co-sign the specified Safe transaction
- 
+
 - [Relay Transaction](./relay/)
-  
+
   Action to relay a Safe transaction that has been approved
 
 ## Setup
@@ -24,14 +24,26 @@ To setup the GitHub actions for yourself it is recommended to use the [Varangian
 
 The actions are setup as a monorepo. Each action is maintained in a separate folder. The `shared-utils` folder contains all shared logic.
 
-* Install dependencies
+- Install dependencies
 
 ```sh
 npm i
 ```
 
-* Build all packages
+- Build all packages
 
 ```sh
 npm run build:all
 ```
+
+### Cosigner Signature Encoding
+
+There are two modes of signature encoding done, one which contains only the signature and the other which also contains the length of the signature.
+
+#### Default Mode
+
+This is the mode where only signature is present based on the cosigner address derived.
+
+#### 1271 Compatible Mode
+
+This is the mode where the signature and the length, both are appended at the end of the signature of a Safe Tx

--- a/actions/check/action.yml
+++ b/actions/check/action.yml
@@ -7,6 +7,10 @@ inputs:
   co-signer-material:
     description: "Private key material used for co-signing"
     required: true
+  signature-1271-compatible:
+    description: 'Flag to indicate if the signature should be 1271 compatible'
+    required: false
+    type: boolean
   safe-tx:
     description: "Safe Transaction to check"
     # required: true

--- a/actions/check/src/main.ts
+++ b/actions/check/src/main.ts
@@ -9,7 +9,7 @@ const getCoSigner = (coSignerMaterial: string): ethers.Wallet => {
   return wallet
 }
 
-const checkTransaction = async (coSignerMaterial: string, safeTx: ExtendedSafeTransaction): Promise<{ coSignerSignature: string, coSignerAddress: string }> => {
+const checkTransaction = async (coSignerMaterial: string, safeTx: ExtendedSafeTransaction, coSignerSig1271Compatible: boolean): Promise<{ coSignerSignature: string, coSignerAddress: string }> => {
   const wallet = getCoSigner(coSignerMaterial)
 
   const safeTxHash = getSafeTxHash(safeTx)
@@ -23,6 +23,13 @@ const checkTransaction = async (coSignerMaterial: string, safeTx: ExtendedSafeTr
   }
   core.info("Generate co-signer signature")
   const coSignerSignature: string = wallet.signingKey.sign(safeTxHash).serialized
+  if (coSignerSig1271Compatible) {
+    // The signature length is appended as a 32 byte word to the end of the signature. And the signature length in this case is always 65 bytes (0x41).
+    const signatureLength = ethers.zeroPadValue("0x41", 32);
+    console.log({ signatureLength });
+    console.log({ coSignerSignature });
+    return { coSignerSignature: coSignerSignature + signatureLength.slice(2), coSignerAddress: wallet.address }
+  }
   console.log({ coSignerSignature });
   return { coSignerSignature, coSignerAddress: wallet.address }
 }
@@ -30,6 +37,7 @@ const checkTransaction = async (coSignerMaterial: string, safeTx: ExtendedSafeTr
 async function run() {
   try {
     const coSignerMaterial = core.getInput('co-signer-material', { required: true });
+    const coSignerSig1271Compatible = core.getBooleanInput('signature-1271-compatible') ?? false;
     const encodedSafeTx = core.getInput('safe-tx')
     if (!encodedSafeTx) {
       // If there is no transaction to check, then we only return the co-signer address
@@ -38,7 +46,7 @@ async function run() {
       return
     }
     const safeTx: ExtendedSafeTransaction = JSON.parse(encodedSafeTx);
-    const output = await checkTransaction(coSignerMaterial, safeTx)
+    const output = await checkTransaction(coSignerMaterial, safeTx, coSignerSig1271Compatible);
     core.setOutput('co-signer-address', output.coSignerAddress);
     core.setOutput('co-signer-signature', output.coSignerSignature);
     /*


### PR DESCRIPTION
## TLDR
- Added a new signature encoding scheme to be compatible with 1271 (allowing us variable length signature)
- README description and `action.yml` updated accordingly.

## LLM Description
This pull request introduces support for 1271-compatible signature encoding in the `check` GitHub Action, along with updates to the documentation and configuration files. The changes include adding a new input parameter for the compatibility flag, implementing logic to handle the 1271-compatible signature format, and updating the documentation to explain the new feature.

### Documentation Updates:
* [`actions/README.md`](diffhunk://#diff-ec0e17031f1d2a1a38f0eee14694ecf3fe047dcb333d045463842019f2a53c2cL27-R49): Added a section explaining the two modes of cosigner signature encoding: Default Mode and 1271 Compatible Mode.

### Configuration Changes:
* [`actions/check/action.yml`](diffhunk://#diff-ec8c9dfbae7445b07b384e19b027ff846da1bedc3655d8a4a9b43045e8be5e06R10-R13): Introduced a new optional boolean input parameter, `signature-1271-compatible`, to enable 1271-compatible signature encoding.

### Code Changes:
* `actions/check/src/main.ts`:
  - Updated the `checkTransaction` function to accept the `coSignerSig1271Compatible` flag and implemented logic to append the signature length as a 32-byte word when the flag is enabled. [[1]](diffhunk://#diff-40935bd81d8e19e3d85f2cb7c2229603f714baf6cc95704e5c413eda0432588cL12-R12) [[2]](diffhunk://#diff-40935bd81d8e19e3d85f2cb7c2229603f714baf6cc95704e5c413eda0432588cR26-R40)
  - Modified the `run` function to retrieve and pass the `signature-1271-compatible` input to the `checkTransaction` function.